### PR TITLE
fix gpg command

### DIFF
--- a/docs/community/verify.md
+++ b/docs/community/verify.md
@@ -63,7 +63,7 @@ gpg --import KEYS # Import KEYS to local
 Then, trust the public key:
 
 ```shell
-gpg --edit-key kie
+gpg --edit-key "Apache KIE Automated Release Signing"
 ```
 
 It will enter the interactive mode, use the following command to trust the key:


### PR DESCRIPTION
```
gpg --edit-key kie
```
 It may pick up "Tiago Bento (Apache KIE release signing)", but the key didn't sign the rc1 files. 

```
gpg --edit-key "Apache KIE Automated Release Signing"
```
explicitly picks up the key we want to trust and proceed the verify steps.