### PR TITLE
[incubator-kie-website-21] Standardize the URLs for documentation lin…

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,14 +7,17 @@ on:
   pull_request:
 
 jobs:
-  deploy:
+  build-docs:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        version: [10.0.x]
     steps:
       - name: Checkout SonataFlow repository
         uses: actions/checkout@v4
         with:
           repository: apache/incubator-kie-kogito-docs
-          ref: 10.0.x
+          ref: ${{ matrix.version }}
           path: sonataflow-docs
 
       - name: Build Sonataflow documentation
@@ -26,7 +29,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: apache/incubator-kie-drools
-          ref: 10.0.x
+          ref: ${{ matrix.version }}
           path: drools
 
       - name: Build Drools documentation
@@ -38,7 +41,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: apache/incubator-kie-docs
-          ref: 10.0.x
+          ref: ${{ matrix.version }}
           path: kogito-docs
 
       - name: Build Kogito documentation
@@ -46,27 +49,55 @@ jobs:
           cd kogito-docs
           mvn -B clean install -Dfull
 
+      - name: Collect built docs
+        run: |
+          mkdir -p docs/${{ matrix.version }}/sonataflow
+          cp -r sonataflow-docs/build/site/* docs/${{ matrix.version }}/sonataflow
+
+          mkdir -p docs/${{ matrix.version }}/drools
+          cp -r drools/drools-docs/target/website/docs/* docs/${{ matrix.version }}/drools
+
+          mkdir -p docs/${{ matrix.version }}/kogito
+          cp -r kogito-docs/doc-content/apache-kie-kogito/target/generated-docs/html_single/* docs/${{ matrix.version }}/kogito
+
+      - name: Upload built docs artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.version }}
+          path: docs/${{ matrix.version }}
+
+  deploy-website:
+    runs-on: ubuntu-latest
+    needs: build-docs
+    steps:
       - name: Checkout Apache KIE Website repository
         uses: actions/checkout@v4
         with:
           path: incubator-kie-website
 
-      - name: Copy Sonataflow docs to Apache KIE static folder
-        run: |
-          mkdir -p incubator-kie-website/static/sonataflow-docs
-          cp -r sonataflow-docs/build/site/* incubator-kie-website/static/sonataflow-docs
+      - name: Prepare docs folder
+        run: mkdir -p docs
 
-      - name: Copy Drools docs to Apache KIE static folder
-        run: |
-          mkdir -p incubator-kie-website/static/drools-docs
-          cp -r drools/drools-docs/target/website/docs/* incubator-kie-website/static/drools-docs
+      - name: Download built docs artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: docs
 
-      - name: Copy Kogito docs to Apache KIE static folder
+      - name: Copy docs to website static folder
         run: |
-          mkdir -p incubator-kie-website/static/kogito-docs
-          cp -r kogito-docs/doc-content/apache-kie-kogito/target/generated-docs/html_single/* incubator-kie-website/static/kogito-docs
+          for ver in $(ls docs); do
+            echo "Processing version: $ver"
+            mkdir -p incubator-kie-website/static/docs/$ver/sonataflow
+            cp -r docs/$ver/sonataflow/* incubator-kie-website/static/docs/$ver/sonataflow
 
-      - name : Build Apache Kie Website
+            mkdir -p incubator-kie-website/static/docs/$ver/drools
+            cp -r docs/$ver/drools/* incubator-kie-website/static/docs/$ver/drools
+
+            mkdir -p incubator-kie-website/static/docs/$ver/kogito
+            cp -r docs/$ver/kogito/* incubator-kie-website/static/docs/$ver/kogito
+          done
+
+      - name: Build Apache KIE Website
         run: |
           cd incubator-kie-website
           npm install

--- a/docs/documentation/documentation.md
+++ b/docs/documentation/documentation.md
@@ -8,14 +8,14 @@ sidebar_position: 0
 
 Apache KIE (incubating) provides live documentation for community in two streams.
 
-1. Development stream - built & published nightly from `main` branch. Usage is limited to testing and development. 
-2. Release stream - built & published after the vote on release canidates passes. We will maintain each released branch until it is deprecated.
+1. Development stream - built & published nightly from `main` branch. Usage is limited to testing and development.
+2. Release stream - built & published after the vote on release candidates passes. We will maintain each released branch until it is deprecated.
 
 ## Source
 
-The source of our documentation is hosted at Github, across multiple repostories.
+The source of our documentation is hosted at Github, across multiple repositories.
 
-See the instructions on how to contribute and build from source by examing the link below.
+See the instructions on how to contribute and build from source by examining the link below.
 
 * [Drools Documentation](https://github.com/apache/incubator-kie-drools/tree/main/drools-docs)
 * [Kogito Documentation](https://github.com/apache/incubator-kie-docs/tree/main/doc-content/apache-kie-kogito)

--- a/docs/documentation/documentation_10.0.0.mdx
+++ b/docs/documentation/documentation_10.0.0.mdx
@@ -8,9 +8,9 @@ sidebar_position: 1
 
 ## Source
 
-The source of our documentation is hosted at Github, across multiple repostories.
+The source of our documentation is hosted at Github, across multiple repositories.
 
-See the instructions on how to contribute and build from source by examing the link below.
+See the instructions on how to contribute and build from source by examining the link below.
 
 * [Drools Documentation](https://github.com/apache/incubator-kie-drools/tree/10.0.x/drools-docs)
 * [Kogito Documentation](https://github.com/apache/incubator-kie-docs/tree/10.0.x/doc-content/apache-kie-kogito)
@@ -18,12 +18,12 @@ See the instructions on how to contribute and build from source by examing the l
 
 ## Drools documentation
 
-<p>Click <a href="../../drools-docs" target="_blank" rel="noopener noreferrer">here</a> to learn about Drools.</p>
+<p>Click <a href="../10.0.x/drools" target="_blank" rel="noopener noreferrer">here</a> to learn about Drools.</p>
 
 ## Kogito documentation
 
-<p>Click <a href="../../kogito-docs" target="_blank" rel="noopener noreferrer">here</a> to learn about Kogito.</p>
+<p>Click <a href="../10.0.x/kogito" target="_blank" rel="noopener noreferrer">here</a> to learn about Kogito.</p>
 
 ## SonataFlow documentation
 
-<p>Click <a href="../../sonataflow-docs" target="_blank" rel="noopener noreferrer">here</a> to learn about SonataFlow.</p>
+<p>Click <a href="../10.0.x/sonataflow" target="_blank" rel="noopener noreferrer">here</a> to learn about SonataFlow.</p>


### PR DESCRIPTION
…k on website

- Prepared for versions matrix


This PR changes the URLs 

from
https://kie.apache.org/drools-docs/
https://kie.apache.org/kogito-docs/
https://kie.apache.org/sonataflow-docs/

to
https://kie.apache.org/docs/10.0.x/drools/
https://kie.apache.org/docs/10.0.x/kogito/
https://kie.apache.org/docs/10.0.x/sonataflow/

Also introduced `matrix` so that we will be able to add versions easily. (At the moment, still `10.0.x` only)

When `10.1.0` will be released, we will
- Change `matrix.version` from `[10.0.x]` to `[10.0.x, 10.1.x]`
- Add `documentation_10.1.0.mdx`
