### PR TITLE
Migrate kogito.org to kie-website #1939

### DIFF
--- a/docs/components/kogito/kogito.md
+++ b/docs/components/kogito/kogito.md
@@ -5,5 +5,26 @@ sidebar_position: 0
 ---
 
 # Kogito
+Cloud-native business automation for building intelligent applications, backed by battle-tested capabilities.
 
-This section is work-in-progress. Please refer to [Documentation](https://kie.apache.org/docs/documentation/) for the latest documentation.
+
+# Kogito ergo cloud
+Kogito (powered by jBPM) is designed from ground up to run at scale on cloud infrastructure. If you think about business automation think about the cloud as this is where your business logic lives these days. By taking advantage of the latest technologies (Quarkus, knative, etc.), you get amazingly fast boot times and instant scaling on orchestration platforms like Kubernetes.
+
+
+# Kogito ergo domain
+Kogito adapts to your business domain rather than the other way around. No more leaking abstraction of the tool into your client applications. Stay focused on what the business is about instead of being concerned with technology behind it.
+
+# Kogito ergo power
+Kogito offers a powerful developer experience based on battle-tested components. Achieve instant developer efficiency by having:
+
+* Tooling embeddable wherever you need it
+* Code generation taking care of 80% of the work
+* Flexibility to customize, only use what you need
+* Simplified local development with live reload
+
+# Examples
+Kogito can be used in many ways, so to help you get started, we provide a wide range of examples demonstrating from simple hello world to more advanced use cases using DMN, BPMN, KNative, Serverless Workflow and more. Head to Kogito examples repository in GitHub and start exploring. The team is constantly updating this repository with new and exciting features as they are added to Kogito.
+
+# Documentation
+Please refer to [Documentation](https://kie.apache.org/docs/documentation/) for the latest walk through examples and documentation.


### PR DESCRIPTION
https://github.com/apache/incubator-kie-issues/issues/1939

So the kogito website does not have that much content. Just full of links to the documentation (that are broken). Here is the "meat" I could find.