### PR TITLE
Migrate sonataflow.org to kie-website #1949

### DIFF
--- a/docs/components/sonataflow/sonataflow.md
+++ b/docs/components/sonataflow/sonataflow.md
@@ -6,4 +6,11 @@ sidebar_position: 0
 
 # Sonataflow
 
-This section is work-in-progress. Please refer to [Documentation](https://kie.apache.org/docs/documentation/) for the latest documentation.
+
+SonataFlow is a tool for building cloud-native workflow applications. You can use it to do the services and events orchestration and choreography. Currently, with SonataFlow you can integrate with services and events in your architecture using:
+
+* CloudEvents. Ideal for an Event-Driven architecture where the services are ready to consume and produce events working in a more reactive way. 
+* Sync or Async REST services invocations via OpenAPI/AsyncAPI. There are options even to directly call a REST service in the architecture or ecosystem. Either async or sync methods are supported depending on your requirements. 
+* Internal Service execution or invocation. SonataFlow is also a workflow framework to build applications. You can use it to create custom services in the same thread to run a lightweight workflow-based application within the same instance.
+
+You can learn how to create, manage, and deploy your workflow applications with the guides included in the [Documentation](https://kie.apache.org/docs/documentation/).


### PR DESCRIPTION
https://github.com/apache/incubator-kie-issues/issues/1949

The sonataflow.org is just the documentation for the web site. For this reason I added few paragraphs of introduction and then link to docs. The actual documentation for all the components needs to moved later.