### PR TITLE
[NO-ISSUE] Change iframe to link because iframe for external site is not allowed

### DIFF
--- a/docs/components/drools/dmn.mdx
+++ b/docs/components/drools/dmn.mdx
@@ -11,12 +11,7 @@ The Decision Model and Notation (DMN™) is a Standard by OMG® providing a comm
 The official webpage of the DMN Standard specification is available at [OMG website](https://www.omg.org/dmn).
 Drools DMN engine is an open source Java™ implementation providing full runtime support for DMN models at Conformance level 3, meaning 100% of the features in the Standard.
 
-<iframe width="560" height="315"
-  src="https://www.youtube.com/embed/rJyYvNk4QZs"
-  title="What is DMN? in 100 seconds" frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen>
-</iframe>
+- [What is DMN? in 100 seconds](https://www.youtube.com/watch?v=rJyYvNk4QZs)
 
 ## At a glance
 

--- a/docs/components/drools/videos.mdx
+++ b/docs/components/drools/videos.mdx
@@ -14,22 +14,12 @@ The KIE Community Youtube channel is an open space for all topics related busine
 ## KIE Live: a business automation live streaming series
 KIE Live is a series of public live streamings for knowledge sharing about any Business Automation topic: business rules, decisions, processes, resource planning, tooling, engine, trusty AI, etc.
 
-<iframe width="560" height="315"
-                src="https://www.youtube.com/embed/videoseries?list=PLo3ZScdD9hW4S94iT3ZgOWm8asSHuMDYn"
-                title="YouTube video player" frameborder="0"
-                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                allowfullscreen></iframe>
-
-You can also bookmark this [playlist](https://www.youtube.com/playlist?list=PLo3ZScdD9hW4S94iT3ZgOWm8asSHuMDYn) with all the previous sessions
+- [KIE Live playlist](https://www.youtube.com/playlist?list=PLo3ZScdD9hW4S94iT3ZgOWm8asSHuMDYn)
 
 ## KIE Drops: for quick learning
 A KIE Drop is a short, focused, five minute (or less) video used to promote an idea, news about the projects under the KIE umbrella, or explanation of key capabilities.
 
-<iframe width="560" height="315"
-    src="https://www.youtube.com/embed/videoseries?list=PLo3ZScdD9hW5agTmsP-_lMz0zzhX_J0KM"
-    title="YouTube video player" frameborder="0"
-    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-    allowfullscreen></iframe>
+- [KIE Drops playlist](https://www.youtube.com/playlist?list=PLo3ZScdD9hW5agTmsP-_lMz0zzhX_J0KM)
 
 Do you have an idea for a KIE Drop? Get in contact with us.
 
@@ -37,24 +27,12 @@ Do you have an idea for a KIE Drop? Get in contact with us.
 A series exploring process & business Automation, where we take you on a general technical and cultural journey through approaches to integrating process and business automation rules.
 This KIE Week will offer a single one-hour session each day.
 
-<iframe
-  width="560" height="315"
-  src="https://www.youtube.com/embed/videoseries?list=PLo3ZScdD9hW6UtFRbgOfYbdrcPkIjatQr"
-  title="YouTube video player" frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
-></iframe>
+- [KIE Week 2021 playlist](https://www.youtube.com/playlist?list=PLo3ZScdD9hW6UtFRbgOfYbdrcPkIjatQr)
 
 ## Drools: DMN Engine
 A collection of presentations covering the DMN open source engine of Drools.
 
-<iframe
-  width="560" height="315"
-  src="https://www.youtube.com/embed/videoseries?list=PLdbdefeRIj9RW_bWDmx17oXzKshu-4T9H"
-  title="YouTube video player" frameborder="0"
-  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-  allowfullscreen
-></iframe>
+- [Drools DMN Engine presentations playlist](https://www.youtube.com/playlist?list=PLdbdefeRIj9RW_bWDmx17oXzKshu-4T9H)
 
 ## Make your own videos
 If you published a public video featuring Drools, let us know and we’ll happily re-share it on our KIE Community channels.


### PR DESCRIPTION
Apache web server configures Content Security Policy (CSP), so iframe for external site is not allowed. e.g. https://kie.apache.org/docs/components/drools/drools_videos/

![Screenshot From 2025-05-12 14-06-52](https://github.com/user-attachments/assets/cfb0fcc4-cfbf-4e0e-8c1b-df128cf898eb)

Changed from iframe to link 

![Screenshot From 2025-05-12 15-55-48](https://github.com/user-attachments/assets/10737895-6f0c-45a6-86fc-c0365f124bbb)
