### PR TITLE
Point /documentation redirect to 10.2.0

### DIFF
--- a/src/pages/documentation.tsx
+++ b/src/pages/documentation.tsx
@@ -2,5 +2,5 @@ import {Redirect} from '@docusaurus/router';
 
 // Latest release — update for each new release
 export default function DocumentationRedirect(): JSX.Element {
-  return <Redirect to="/documentation/documentation_10.1.0" />;
+  return <Redirect to="/documentation/documentation_10.2.0" />;
 }


### PR DESCRIPTION
`/documentation` was still redirecting to `documentation_10.1.0`, so the footer "Documentation" link and any direct/bookmarked links landed on the previous release instead of the latest one.

`src/pages/documentation.tsx` is a hand-maintained redirect ("Latest release — update for each new release") that was missed when the 10.2.0 documentation page was added in c615d87.

The navbar "Documentation" item is unaffected — it's a `docSidebar` link and already lands on 10.2.0 via `sidebar_position: 98`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)